### PR TITLE
♻ Changed all contracts and interfaces to `Hemify` to match project name.

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,17 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="3944fe08-65ba-4f03-9463-766a2133401a" name="Changes" comment="">
-      <change beforePath="$PROJECT_DIR$/src/contracts/nftSwap/Swap.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/contracts/nftSwap/Swap.sol" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/interfaces/ISwap.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/interfaces/ISwap.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/contracts/Control.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/contracts/HemifyControl.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/contracts/Escrow.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/contracts/HemifyEscrow.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/contracts/OpenAuctionV1/OpenAuctionV1.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/contracts/hemify-auction-v1/HemifyAuctionV1.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/contracts/Treasury.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/contracts/HemifyTreasury.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/contracts/nftSwap/Swap.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/contracts/hemify-swap/HemifySwap.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/interfaces/IControl.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/interfaces/IHemifyControl.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/interfaces/IEscrow.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/interfaces/IHemifyEscrow.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/interfaces/IOpenAuctionV1.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/interfaces/IHemifyAuctionV1.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/interfaces/ISwap.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/interfaces/IHemifySwap.sol" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/interfaces/ITreasury.sol" beforeDir="false" afterPath="$PROJECT_DIR$/src/interfaces/IHemifyTreasury.sol" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/src/contracts/HemifyControl.sol
+++ b/src/contracts/HemifyControl.sol
@@ -3,26 +3,26 @@ pragma solidity 0.8.19;
 
 import {AggregatorV3Interface}
     from "chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-import {IControl} from "../interfaces/IControl.sol";
+import {IHemifyControl} from "../interfaces/IHemifyControl.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 import {Ownable2Step} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 
 /**
-* @title Control
+* @title HemifyControl
 * @author fps (@0xfps).
-* @dev  Control contract.
+* @dev  HemifyControl contract.
 *       A contract for setting and revoking support for a particular IERC20 tokens,
 *       making them acceptable as a means of making bids for listed auctions.
 */
 
-contract Control is IControl, Ownable2Step {
+contract HemifyControl is IHemifyControl, Ownable2Step {
     mapping(IERC20 => AggregatorV3Interface) private supportedTokens;
     mapping(IERC721 => bool) public supportedSwapNFTs;
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     * @notice   `token` and `agg` cannot be zero addresses and function is only
     *           callable by the owner.
     */
@@ -36,7 +36,7 @@ contract Control is IControl, Ownable2Step {
     }
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     * @notice Function is only callable by the owner.
     */
     function revokeToken(IERC20 token) public onlyOwner {
@@ -46,7 +46,7 @@ contract Control is IControl, Ownable2Step {
     }
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     * @notice   `nft` cannot be zero addresses and function is only callable
     *           by the owner.
     */
@@ -57,7 +57,7 @@ contract Control is IControl, Ownable2Step {
     }
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     * @notice Function is only callable by the owner.
     */
     function revokeSwapNFT(IERC721 nft) public onlyOwner {
@@ -66,21 +66,21 @@ contract Control is IControl, Ownable2Step {
     }
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     */
     function isSupported(IERC20 token) public view returns (bool) {
         return address(supportedTokens[token]) != address(0);
     }
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     */
     function isSupportedForSwap(IERC721 nft) public view returns (bool) {
         return supportedSwapNFTs[nft];
     }
 
     /**
-    * @inheritdoc IControl
+    * @inheritdoc IHemifyControl
     */
     function getTokenAggregator(IERC20 token) external view returns (AggregatorV3Interface) {
         if (!isSupported(token)) revert NotSupported();

--- a/src/contracts/HemifyEscrow.sol
+++ b/src/contracts/HemifyEscrow.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {IEscrow} from "../interfaces/IEscrow.sol";
+import {IHemifyEscrow} from "../interfaces/IHemifyEscrow.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Receiver} from "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
@@ -9,15 +9,15 @@ import {Gated, SimpleMultiSig} from "./utils/Gated.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /**
- * @title Escrow
+ * @title HemifyEscrow
  * @author fps (@0xfps).
- * @dev  Escrow contract.
+ * @dev  HemifyEscrow contract.
  *       A contract to hold NFTs during auction duration.
  *       Any contract can interact with this contract as long as it's been
  *       `allow`ed by this contract via the `Gated` contract via multisig.
  */
 
-contract Escrow is IEscrow, IERC721Receiver, Gated, ReentrancyGuard {
+contract Escrow is IHemifyEscrow, IERC721Receiver, Gated, ReentrancyGuard {
     /// @dev Initialize protective multi-sig of at least 5 addresses.
     /// @param _addresses 5 or more addresses for multi-sig protection.
     constructor(address[] memory _addresses) 

--- a/src/contracts/HemifyTreasury.sol
+++ b/src/contracts/HemifyTreasury.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ITreasury} from "../interfaces/ITreasury.sol";
+import {IHemifyTreasury} from "../interfaces/IHemifyTreasury.sol";
 
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -10,7 +10,7 @@ import {Gated, SimpleMultiSig} from "./utils/Gated.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 
 /**
- * @title Treasury
+ * @title HemifyTreasury
  * @author fps (@0xfps).
  * @dev  Treasury contract.
  *       A contract to hold all tokens and ETH.
@@ -18,7 +18,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.
  *       `allow`ed by this contract.
  */
 
-contract Treasury is ITreasury, Gated, ReentrancyGuard {
+contract HemifyTreasury is IHemifyTreasury, Gated, ReentrancyGuard {
     using SafeERC20 for IERC20;
 
     /// @dev Initialize protective multi-sig of at least 5 addresses.
@@ -34,7 +34,7 @@ contract Treasury is ITreasury, Gated, ReentrancyGuard {
         emit ETHDeposit(msg.value);
     }
 
-    /// @inheritdoc ITreasury
+    /// @inheritdoc IHemifyTreasury
     /// @return bool Status.
     function deposit() external payable onlyAllowed returns (bool) {
         emit ETHDeposit(msg.value);
@@ -91,7 +91,7 @@ contract Treasury is ITreasury, Gated, ReentrancyGuard {
     /**
     * @dev Deposits `amount` amount of `token` tokens from `from` to this contract.
     * @notice   This contract will be approved by `from` to allow easy deposits, but
-    *           will only be callable by the OpenAuction or any other added contract.
+    *           will only be callable by the HemifyAuction or any other added contract.
     *           Assertion that the difference between the token balance of the contract
     *           after deposit and before deposit is >= the amount deposited is made.
     * @param from   Sender.
@@ -111,7 +111,7 @@ contract Treasury is ITreasury, Gated, ReentrancyGuard {
         /// @dev Checks of IERC20 being supported are done in the Auction.
         uint256 prevBal = token.balanceOf(address(this));
 
-        /// @dev    `from` must approve Treasury address to move funds
+        /// @dev    `from` must approve HemifyTreasury address to move funds
         ///         via approve().
         token.safeTransferFrom(from, address(this), amount);
 
@@ -124,7 +124,7 @@ contract Treasury is ITreasury, Gated, ReentrancyGuard {
 
     /**
     * @dev Sends `amount` amount of `token` tokens to `to` from this contract.
-    * @notice   Assertions as to balances are not made as function is non-reentrant.
+    * @notice Assertions as to balances are not made as function is non-reentrant.
     * @param token  Token.
     * @param to     Sender.
     * @param amount Amount to send, which will always be <= this contract's balance.

--- a/src/contracts/hemify-auction-v1/HemifyAuctionV1.sol
+++ b/src/contracts/hemify-auction-v1/HemifyAuctionV1.sol
@@ -3,27 +3,27 @@ pragma solidity 0.8.19;
 
 import {AggregatorV3Interface}
     from "chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
-import {IControl} from "../../interfaces/IControl.sol";
+import {IHemifyControl} from "../../interfaces/IHemifyControl.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import {IEscrow} from "../../interfaces/IEscrow.sol";
-import {IOpenAuctionV1} from "../../interfaces/IOpenAuctionV1.sol";
-import {ITreasury} from "../../interfaces/ITreasury.sol";
+import {IHemifyEscrow} from "../../interfaces/IHemifyEscrow.sol";
+import {IHemifyAuctionV1} from "../../interfaces/IHemifyAuctionV1.sol";
+import {IHemifyTreasury} from "../../interfaces/IHemifyTreasury.sol";
 
 import {PriceChecker} from "../utils/PriceChecker.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import {Taxes} from "../utils/Taxes.sol";
 
 /**
-* @title OpenAuctionV1.
+* @title HemifyAuctionV1.
 * @author fps (@0xfps).
 * @dev  Core Auction Contract.
 * @custom:owner     BotBuddyz.
 * @custom:version   0.0.1.
 * @notice   NFT Auction contract. NFTs are listed by the owner or an approved
 *           personnel via the `list()` function. This will return the `id` of the
-*           auction. The NFT is sent to the `Escrow` contract for the duration of
-*           the auction.
+*           auction. The NFT is sent to the `HemifyEscrow` contract for the duration
+*           of the auction.
 *
 *           Auctions can be closed at any time on the condition that there have been
 *           no bids on it.
@@ -51,10 +51,10 @@ import {Taxes} from "../utils/Taxes.sol";
 *           be cancelled, rather, reclaimed.
 */
 
-contract OpenAuctionV1 is IOpenAuctionV1, PriceChecker, Taxes {
-    IControl internal control;
-    IEscrow internal escrow;
-    ITreasury internal treasury;
+contract HemifyAuctionV1 is IHemifyAuctionV1, PriceChecker, Taxes {
+    IHemifyControl internal control;
+    IHemifyEscrow internal escrow;
+    IHemifyTreasury internal treasury;
 
     /// @dev Auction index count.
     uint256 private _index;
@@ -77,9 +77,9 @@ contract OpenAuctionV1 is IOpenAuctionV1, PriceChecker, Taxes {
             _treasury == address(0)
         ) revert ZeroAddress();
 
-        control = IControl(_control);
-        escrow = IEscrow(_escrow);
-        treasury = ITreasury(_treasury);
+        control = IHemifyControl(_control);
+        escrow = IHemifyEscrow(_escrow);
+        treasury = IHemifyTreasury(_treasury);
     }
 
     /// @dev Handle incoming funds by sending them to treasury.
@@ -97,7 +97,7 @@ contract OpenAuctionV1 is IOpenAuctionV1, PriceChecker, Taxes {
     *       for auction.
     * @notice   Auctioneers are allowed to list any NFT that they own or are
     *           approved to spend by the owner. Of course, before NFTs are listed
-    *           for auction, the `Escrow` contract must be first approved via a
+    *           for auction, the `HemifyEscrow` contract must be first approved via a
     *           `setApprovalForAll()` in the `ERC721` NFT contract.
     *
     *           Auction min prices cannot be `0`.
@@ -208,7 +208,7 @@ contract OpenAuctionV1 is IOpenAuctionV1, PriceChecker, Taxes {
     * @dev Allows `msg.sender` to make a token bid on an existing auction.
     * @notice   Allows anyone to make a token bid on an existing auction.
     *           Auction must exist and will be LIVE.
-    *           Tokens will only be approved tokens in `Control`.
+    *           Tokens will only be approved tokens in `HemifyControl`.
     *           All token amount sent will be evaluated to their ETH worth at
     *           the time of bidding (and `bid()` logic runs).
     *           Bids must be higher than `minPrice` (for first bid) and

--- a/src/contracts/hemify-swap/HemifySwap.sol
+++ b/src/contracts/hemify-swap/HemifySwap.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.19;
 
-import {IControl} from "../../interfaces/IControl.sol";
-import {IEscrow} from "../../interfaces/IEscrow.sol";
+import {IHemifyControl} from "../../interfaces/IHemifyControl.sol";
+import {IHemifyEscrow} from "../../interfaces/IHemifyEscrow.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import {ISwap} from "../../interfaces/ISwap.sol";
-import {ITreasury} from "../../interfaces/ITreasury.sol";
+import {IHemifySwap} from "../../interfaces/IHemifySwap.sol";
+import {IHemifyTreasury} from "../../interfaces/IHemifyTreasury.sol";
 
 /**
-* @title Swap
+* @title HemifySwap
 * @author fps (@0xfps).
-* @dev  Swap contract.
+* @dev  HemifySwap contract.
 * @notice   This contract allows two parties to swap their NFTs via an
 *           order book model approach.
 *
@@ -30,12 +30,14 @@ import {ITreasury} from "../../interfaces/ITreasury.sol";
 *           Orders set to LISTED can as well be deleted by their 'placer'.
 */
 
-contract Swap is ISwap {
-    IControl internal control;
-    IEscrow internal escrow;
-    ITreasury internal treasury;
+contract HemifySwap is IHemifySwap {
+    IHemifyControl internal control;
+    IHemifyEscrow internal escrow;
+    IHemifyTreasury internal treasury;
 
+    // Set now, variable later.
     uint256 public fee = 0.05 ether;
+    // Set now, variable later.
     uint256 public markUpLimit = 2 ether;
     mapping(bytes32 => Order) private orders;
 
@@ -51,9 +53,9 @@ contract Swap is ISwap {
             _treasury == address(0)
         ) revert ZeroAddress();
 
-        control = IControl(_control);
-        escrow = IEscrow(_escrow);
-        treasury = ITreasury(_treasury);
+        control = IHemifyControl(_control);
+        escrow = IHemifyEscrow(_escrow);
+        treasury = IHemifyTreasury(_treasury);
     }
 
     /**

--- a/src/interfaces/IHemifyAuctionV1.sol
+++ b/src/interfaces/IHemifyAuctionV1.sol
@@ -5,13 +5,13 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
-* @title IOpenAuctionV1
+* @title IHemifyAuctionV1
 * @author fps (@0xfps).
-* @dev  Open Auction V1 contract interface.
-*       This interface controls the basic functionalities on the `OpenAuction` contract.
+* @dev  HemifyAuction V1 contract interface.
+*       This interface controls the basic functionalities on the `HemifyAuction` contract.
 */
 
-interface IOpenAuctionV1 {
+interface IHemifyAuctionV1 {
     /**
     * @dev  Specifies the current state of the auction.
     *       DORMANT:   Auction has not yet begun.

--- a/src/interfaces/IHemifyControl.sol
+++ b/src/interfaces/IHemifyControl.sol
@@ -7,13 +7,13 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
-* @title IControl
+* @title IHemifyControl
 * @author fps (@0xfps).
-* @dev  Control contract interface.
-*       This interface controls the `Control` contract.
+* @dev  HemifyControl contract interface.
+*       This interface controls the `HemifyControl` contract.
 */
 
-interface IControl {
+interface IHemifyControl {
     /// @dev    Events for different supports and revokes of tokens for payments.
     /// @notice token IERC20 token address supported or revoked.
     event TokenSupportedForAuction(IERC20 indexed token);

--- a/src/interfaces/IHemifyEscrow.sol
+++ b/src/interfaces/IHemifyEscrow.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.19;
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
-* @title IEscrow
+* @title IHemifyEscrow
 * @author fps (@0xfps).
-* @dev  Escrow contract interface.
-*       This interface controls the `Escrow` contract.
+* @dev  HemifyEscrow contract interface.
+*       This interface controls the `HemifyEscrow` contract.
 */
 
-interface IEscrow {
+interface IHemifyEscrow {
     /// @dev Events for NFTDeposit and Sending from contract.
     /// @param nft  NFT address.
     /// @param id   NFT id.

--- a/src/interfaces/IHemifySwap.sol
+++ b/src/interfaces/IHemifySwap.sol
@@ -4,13 +4,13 @@ pragma solidity 0.8.19;
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /**
-* @title ISwap
+* @title IHemifySwap
 * @author fps (@0xfps).
-* @dev  Swap contract interface.
-*       This interface controls the `Swap` contract.
+* @dev  HemifySwap contract interface.
+*       This interface controls the `HemifySwap` contract.
 */
 
-interface ISwap {
+interface IHemifySwap {
     enum OrderState {
         NULL,
         LISTED

--- a/src/interfaces/IHemifyTreasury.sol
+++ b/src/interfaces/IHemifyTreasury.sol
@@ -4,14 +4,14 @@ pragma solidity 0.8.19;
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
- * @title ITreasury
+ * @title IHemifyTreasury
  * @author fps (@0xfps).
- * @dev  Treasury contract interface.
- *       This interface controls the `Treasury` contract.
- *       Treasury holds ETH and tokens over the course of the auction.
+ * @dev  HemifyTreasury contract interface.
+ *       This interface controls the `HemifyTreasury` contract.
+ *       HemifyTreasury holds ETH and tokens over the course of the auction.
  */
 
-interface ITreasury {
+interface IHemifyTreasury {
     /// @dev Events for different actions.
     /// @param amount  Amount deposited or transferred.
     event ETHDeposit(uint256 indexed amount);


### PR DESCRIPTION
All contracts and interfaces have been changed to `Hemify<Previous name>` for contracts and `IHemify<Previous name>` for interfaces.